### PR TITLE
Stop using printf for error reporting, use ErrorMsg or LogMsg.

### DIFF
--- a/src/error.c
+++ b/src/error.c
@@ -9,7 +9,7 @@
 
 #include "error.h"
 
-void LogMsgv(loglevel level, const char *filename, int lineno, const char *format, va_list ap)
+static void LogMsgv(loglevel level, const char *filename, int lineno, const char *format, va_list ap)
 {
     /* If an invalid log level is specified, default to error. */
     if (level >= LOGLEVEL_COUNT) {

--- a/src/error.c
+++ b/src/error.c
@@ -9,74 +9,45 @@
 
 #include "error.h"
 
-/*
- ** Code for printing error message.
- */
-
-/* Find a good place to break "msg" so that its length is at least "min"
- ** but no more than "max".  Make the point as close to max as possible.
- */
-static int findbreak(msg,min,max)
-char *msg;
-int min;
-int max;
+void LogMsgv(loglevel level, const char *filename, int lineno, const char *format, va_list ap)
 {
-    int i,spot;
-    char c;
-    for(i=spot=min; i<=max; i++){
-        c = msg[i];
-        if( c=='\t' ) msg[i] = ' ';
-        if( c=='\n' ){ msg[i] = ' '; spot = i; break; }
-        if( c==0 ){ spot = i; break; }
-        if( c=='-' && i<max-1 ) spot = i+1;
-        if( c==' ' ) spot = i;
+    /* If an invalid log level is specified, default to error. */
+    if (level >= LOGLEVEL_COUNT) {
+        level = LOGLEVEL_ERROR;
     }
-    return spot;
-}
-
-/*
- ** The error message is split across multiple lines if necessary.  The
- ** splits occur at a space, if there is a space available near the end
- ** of the line.
- */
-#define ERRMSGSIZE  10000 /* Hope this is big enough.  No way to error check */
-#define LINEWIDTH      79 /* Max width of any output line */
-#define PREFIXLIMIT    30 /* Max width of the prefix on each line */
-void ErrorMsg(const char *filename, int lineno, const char *format, ...){
-    char errmsg[ERRMSGSIZE];
-    char prefix[PREFIXLIMIT+10];
-    int errmsgsize;
-    int prefixsize;
-    int availablewidth;
-    va_list ap;
-    int end, restart, base;
     
-    va_start(ap, format);
+    static char *const levelStrings[] = {
+        /* LOGLEVEL_INFO    */ "info",
+        /* LOGLEVEL_WARNING */ "warning",
+        /* LOGLEVEL_ERROR   */ "error",
+        /* LOGLEVEL_COUNT   */ NULL
+    };
+    
+    char *const levelString = levelStrings[(int)level];
+    
     /* Prepare a prefix to be prepended to every output line */
-    if( lineno>0 ){
-        sprintf(prefix,"%.*s:%d: ",PREFIXLIMIT-10,filename,lineno);
-    }else{
-        sprintf(prefix,"%.*s: ",PREFIXLIMIT-10,filename);
+    if (lineno > 0) {
+        fprintf(stdout, "%s:%d: %s: ", filename, lineno, levelString);
+    } else {
+        fprintf(stdout, "%s: %s: ", filename, levelString);
     }
-    prefixsize = (int)strlen(prefix);
-    availablewidth = LINEWIDTH - prefixsize;
     
     /* Generate the error message */
-    vsprintf(errmsg,format,ap);
+    vfprintf(stdout, format, ap);
+}
+
+void LogMsg(loglevel level, const char *filename, int lineno, const char *format, ...)
+{
+    va_list ap;
+    va_start(ap, format);
+    LogMsgv(level, filename, lineno, format, ap);
     va_end(ap);
-    errmsgsize = (int)strlen(errmsg);
-    /* Remove trailing '\n's from the error message. */
-    while( errmsgsize>0 && errmsg[errmsgsize-1]=='\n' ){
-        errmsg[--errmsgsize] = 0;
-    }
-    
-    /* Print the error message */
-    base = 0;
-    while( errmsg[base]!=0 ){
-        end = restart = findbreak(&errmsg[base],0,availablewidth);
-        restart += base;
-        while( errmsg[restart]==' ' ) restart++;
-        fprintf(stdout,"%s%.*s\n",prefix,end,&errmsg[base]);
-        base = restart;
-    }
+}
+
+void ErrorMsg(const char *filename, int lineno, const char *format, ...)
+{
+    va_list ap;
+    va_start(ap, format);
+    LogMsgv(LOGLEVEL_ERROR, filename, lineno, format, ap);
+    va_end(ap);
 }

--- a/src/error.h
+++ b/src/error.h
@@ -12,6 +12,33 @@
 
 #include "lemon.h"
 
-void ErrorMsg(const char *, int, const char *, ...);
+enum {
+    LINENO_NONE = 0
+};
+
+typedef enum e_loglevel {
+    LOGLEVEL_INFO = 0,
+    LOGLEVEL_WARNING,
+    LOGLEVEL_ERROR,
+    LOGLEVEL_COUNT
+} loglevel;
+
+/**
+ * Report a message to standard output.
+ *
+ * @param filename The name of the input file.
+ * @param lineno The line number within the input file to which the message corresponds, or LINENO_NONE.
+ * @param format The printf-style format string for the error.
+ */
+void LogMsg(loglevel level, const char *filename, int lineno, const char *format, ...);
+
+/**
+ * Report an error message to standard output.
+ *
+ * @param filename The name of the input file.
+ * @param lineno The line number within the input file to which the error corresponds, or LINENO_NONE.
+ * @param format The printf-style format string for the error.
+ */
+void ErrorMsg(const char *filename, int lineno, const char *format, ...);
 
 #endif /* defined(__lemon_error_h__) */

--- a/src/parse.c
+++ b/src/parse.c
@@ -67,8 +67,7 @@ static void parseonetoken(struct pstate *psp)
     char *x;
     x = Strsafe(psp->tokenstart);     /* Save the token permanently */
 #if 0
-    printf("%s:%d: Token=[%s] state=%d\n",psp->filename,psp->tokenlineno,
-           x,psp->state);
+    LogMsg(LOGLEVEL_INFO, psp->filename, psp->tokenlineno, "Token=[%s] state=%d\n", x,psp->state);
 #endif
     switch( psp->state ){
         case INITIALIZE:

--- a/src/report.c
+++ b/src/report.c
@@ -50,7 +50,7 @@ PRIVATE FILE *file_open(struct lemon *lemp, char *suffix, char *mode)
         lemp->outname = file_makename(lemp, suffix);
         fp = fopen(lemp->outname,mode);
         if( fp==0 && *mode=='w' ){
-            fprintf(stderr,"Can't open file \"%s\".\n",lemp->outname);
+            ErrorMsg(lemp->filename, LINENO_NONE, "Can't open file \"%s\".\n",lemp->outname);
             lemp->errorcnt++;
             return 0;
         }


### PR DESCRIPTION
Use ErrorMsg for error and LogMsg for non-error messages. Also changes the logging format to match that of clang for easier integration with existing toolchains.
